### PR TITLE
Add API method getAccountsBulk

### DIFF
--- a/src/java/nxt/http/APIEnum.java
+++ b/src/java/nxt/http/APIEnum.java
@@ -59,6 +59,7 @@ public enum APIEnum {
     GENERATE_TOKEN("generateToken", GenerateToken.instance),
     GENERATE_FILE_TOKEN("generateFileToken", GenerateFileToken.instance),
     GET_ACCOUNT("getAccount", GetAccount.instance),
+    GET_ACCOUNTS_BULK("getAccountsBulk", GetAccountsBulk.instance),
     GET_ACCOUNT_BLOCK_COUNT("getAccountBlockCount", GetAccountBlockCount.instance),
     GET_ACCOUNT_BLOCK_IDS("getAccountBlockIds", GetAccountBlockIds.instance),
     GET_ACCOUNT_BLOCKS("getAccountBlocks", GetAccountBlocks.instance),

--- a/src/java/nxt/http/GetAccountsBulk.java
+++ b/src/java/nxt/http/GetAccountsBulk.java
@@ -1,0 +1,87 @@
+package nxt.http;
+
+import nxt.Db;
+import nxt.crypto.Crypto;
+import nxt.db.TransactionalDb;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.JSONStreamAware;
+
+import javax.servlet.http.HttpServletRequest;
+import java.sql.*;
+
+
+public class GetAccountsBulk extends APIServlet.APIRequestHandler {
+    static final GetAccountsBulk instance = new GetAccountsBulk();
+    protected static final TransactionalDb db = Db.db;
+
+    private GetAccountsBulk() {
+        super(new APITag[] {APITag.ACCOUNTS}, "minBalanceNQT", "pageSize", "page");
+    }
+
+    @Override
+    protected JSONStreamAware processRequest(HttpServletRequest request) throws ParameterException {
+        int pageSize;
+        int page;
+        long minBalanceNQT;
+        try {
+            pageSize = Integer.parseInt(request.getParameter("pageSize"));
+            if(pageSize < 1 || pageSize > 100) {
+                throw new ParameterException(JSONResponses.INCORRECT_PAGE_SIZE);
+            }
+        } catch (NumberFormatException e) {
+            throw new ParameterException(JSONResponses.INCORRECT_PAGE_SIZE);
+        }
+        try {
+            page = Integer.parseInt(request.getParameter("page"));
+            if(page < 0) {
+                throw new ParameterException(JSONResponses.INCORRECT_PAGE_SIZE);
+            }
+        } catch (NumberFormatException e) {
+            throw new ParameterException(JSONResponses.INCORRECT_PAGE);
+        }
+        try {
+            minBalanceNQT = Long.parseLong(request.getParameter("minBalanceNQT"));
+        } catch (NumberFormatException e) {
+            minBalanceNQT = 0;
+        }
+
+
+
+        JSONObject response = new JSONObject();
+        try (Connection con = db.getConnection(); PreparedStatement pstmt = con.prepareStatement(
+                "SELECT ID,UNCONFIRMED_BALANCE,LATEST,FORGED_BALANCE,ACTIVE_LESSEE_ID,HEIGHT " +
+                        "FROM ACCOUNT " +
+                        "WHERE LATEST=TRUE AND UNCONFIRMED_BALANCE >= ? " +
+                        "ORDER BY UNCONFIRMED_BALANCE DESC " +
+                        "OFFSET ? ROWS FETCH NEXT ? ROWS ONLY")) {
+            pstmt.setLong(1, minBalanceNQT);
+            pstmt.setInt(2, page*pageSize);
+            pstmt.setInt(3, pageSize);
+            try (ResultSet rs = pstmt.executeQuery();) {
+
+                JSONArray arr = new JSONArray();
+                while (rs.next()) {
+                    JSONObject o = new JSONObject();
+                    o.put("ID", "GMD-"+Crypto.rsEncode(rs.getLong("ID")));
+                    o.put("UNCONFIRMED_BALANCE", rs.getLong("UNCONFIRMED_BALANCE"));
+                    o.put("FORGED_BALANCE", rs.getLong("FORGED_BALANCE"));
+                    Long lesee = rs.getLong("ACTIVE_LESSEE_ID");
+                    if (lesee != 0) {
+                        o.put("ACTIVE_LESSEE_ID", "GMD-"+Crypto.rsEncode(lesee));
+                    }
+
+                    o.put("HEIGHT", rs.getLong("HEIGHT"));
+
+                    arr.add(o);
+
+                }
+                response.put("Accounts",arr);
+            }
+
+        } catch (SQLException e) {
+            throw new RuntimeException(e.toString(), e);
+        }
+        return response;
+    }
+}

--- a/src/java/nxt/http/JSONResponses.java
+++ b/src/java/nxt/http/JSONResponses.java
@@ -156,6 +156,8 @@ public final class JSONResponses {
     public static final JSONStreamAware INCORRECT_EC_BLOCK = incorrect("ecBlockId", "ecBlockId does not match the block id at ecBlockHeight");
     public static final JSONStreamAware INCORRECT_ASSET_PROPERTY_NAME_LENGTH = incorrect("property", "(length must be > 0 but less than " + Constants.MAX_ASSET_PROPERTY_NAME_LENGTH + " characters)");
     public static final JSONStreamAware INCORRECT_ASSET_PROPERTY_VALUE_LENGTH = incorrect("value", "(length must be less than " + Constants.MAX_ASSET_PROPERTY_VALUE_LENGTH + " characters)");
+    public static final JSONStreamAware INCORRECT_PAGE_SIZE = incorrect("pageSize", "Page size must be integer between 1 and 100");
+    public static final JSONStreamAware INCORRECT_PAGE = incorrect("page", "page must be integer. page 0 is first page");
 
     public static final JSONStreamAware NOT_ENOUGH_FUNDS;
     static {

--- a/src/java/nxt/http/callers/ApiSpec.java
+++ b/src/java/nxt/http/callers/ApiSpec.java
@@ -107,7 +107,7 @@ public enum ApiSpec {
 
     getAccount(null, "account", "includeLessors", "includeAssets", "includeCurrencies", "includeEffectiveBalance", "requireBlock", "requireLastBlock"),
 
-    getAccountsBulk(null, "minBalanceNQT", "pageSize", "page"),
+    getAccountsBulk(null, "minBalanceNQT", "pageSize", "page", "includeDescription"),
 
     blacklistAPIProxyPeer(null, "peer"),
 

--- a/src/java/nxt/http/callers/ApiSpec.java
+++ b/src/java/nxt/http/callers/ApiSpec.java
@@ -107,6 +107,8 @@ public enum ApiSpec {
 
     getAccount(null, "account", "includeLessors", "includeAssets", "includeCurrencies", "includeEffectiveBalance", "requireBlock", "requireLastBlock"),
 
+    getAccountsBulk(null, "minBalanceNQT", "pageSize", "page"),
+
     blacklistAPIProxyPeer(null, "peer"),
 
     getPeer(null, "peer"),


### PR DESCRIPTION
Add new API method that returns all wallets ordered by GMD balance from large to small.
Data can be retrieved in pages of at most 100 elements each page.