### PR TITLE
Last transaction height balance bulk

### DIFF
--- a/src/java/nxt/http/APIEnum.java
+++ b/src/java/nxt/http/APIEnum.java
@@ -60,6 +60,7 @@ public enum APIEnum {
     GENERATE_FILE_TOKEN("generateFileToken", GenerateFileToken.instance),
     GET_ACCOUNT("getAccount", GetAccount.instance),
     GET_ACCOUNTS_BULK("getAccountsBulk", GetAccountsBulk.instance),
+    GET_LAST_INBOUND_TX_HEIGHT_BULK("getLastInboundTxHeightBulk", GetLastInboundTxHeightBulk.instance),
     GET_MAX_SUPPLY("getMaxSupply", GetSupply.instance),
     GET_TOTAL_SUPPLY("getTotalSupply", GetSupply.instance),
     GET_TRANSACTIONS_BULK("getTransactionsBulk", GetTransactionsBulk.instance),

--- a/src/java/nxt/http/GetLastInboundTxHeightBulk.java
+++ b/src/java/nxt/http/GetLastInboundTxHeightBulk.java
@@ -1,0 +1,189 @@
+package nxt.http;
+
+import nxt.Db;
+import nxt.crypto.Crypto;
+import nxt.db.TransactionalDb;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.JSONStreamAware;
+
+import javax.servlet.http.HttpServletRequest;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.function.Predicate;
+
+
+public class GetLastInboundTxHeightBulk extends APIServlet.APIRequestHandler {
+    static final GetLastInboundTxHeightBulk instance = new GetLastInboundTxHeightBulk();
+    protected static final TransactionalDb db = Db.db;
+
+
+    private GetLastInboundTxHeightBulk() {
+        super(new APITag[] {APITag.TRANSACTIONS});
+    }
+
+    @Override
+    protected boolean requirePost() {
+        return true;
+    }
+
+    @Override
+    protected JSONStreamAware processRequest(HttpServletRequest request) throws ParameterException {
+
+        Integer pageSize = getIntParamFromRequest(request, "pageSize", i->i<1||i>100 , JSONResponses.INCORRECT_PAGE_SIZE , false);
+        Integer page = getIntParamFromRequest(request, "page", i->i<0 , JSONResponses.INCORRECT_PAGE, false);
+
+        long senderRSId=decodeAddrToLongId(request.getParameter("filterBySender"));
+        long recvRSId=decodeAddrToLongId(request.getParameter("filterByReceiver"));
+
+        Integer typeId, subTypeId;
+        typeId = getIntParamFromRequest(request, "filterByType", i->false, JSONResponses.INCORRECT_TYPE, true);
+        subTypeId = getIntParamFromRequest(request, "filterBySubtype", i->false, JSONResponses.INCORRECT_SUBTYPE , true);
+
+        Integer minHeight, maxHeight;
+        minHeight = getIntParamFromRequest(request, "minHeight", i->i<0, JSONResponses.INCORRECT_MIN_HEIGHT, true);
+        maxHeight = getIntParamFromRequest(request, "maxHeight", i->(i<0 || (minHeight!=null&& minHeight > i)), JSONResponses.INCORRECT_MAX_HEIGHT, true);
+
+
+
+        try (Connection con = db.getConnection(); PreparedStatement pstmt = con.prepareStatement(
+                "SELECT * "+
+                        "FROM TRANSACTION " +
+                        "WHERE TRUE "+
+                        (senderRSId!=0 ? "AND ? = SENDER_ID ":"") +
+                        (recvRSId!=0 ? "AND ? = RECIPIENT_ID ":"") +
+                        (typeId!=null ? "AND ? = TYPE ":"") +
+                        (subTypeId!=null ? "AND ? = SUBTYPE ":"") +
+                        (minHeight!=null? "AND ? <= HEIGHT ": "") +
+                        (maxHeight!=null? "AND ? >= HEIGHT ": "") +
+                        "ORDER BY TIMESTAMP DESC " +
+                        "OFFSET ? ROWS FETCH NEXT ? ROWS ONLY")) {
+            int offset = 0;
+            if (senderRSId!=0){
+                pstmt.setLong(++offset,senderRSId);
+            }
+            if (recvRSId!=0){
+                pstmt.setLong(++offset,recvRSId);
+            }
+            if(typeId!=null){
+                pstmt.setInt(++offset,typeId);
+            }
+            if(subTypeId!=null){
+                pstmt.setInt(++offset,subTypeId);
+            }
+            if(minHeight!=null){
+                pstmt.setInt(++offset,minHeight);
+            }
+            if(maxHeight!=null){
+                pstmt.setInt(++offset,maxHeight);
+            }
+            pstmt.setInt(++offset, page*pageSize);
+            pstmt.setInt(++offset, pageSize);
+
+            JSONObject response = new JSONObject();
+            response.put("Transactions", executePreparedStatement(pstmt));
+            return response;
+        } catch (SQLException e) {
+            throw new RuntimeException(e.toString(), e);
+        }
+    }
+
+    /**
+     *
+     * @param request
+     * @param parameterName
+     * @param predicateCheckFail condition to be applied on the output integer. If true will throw ParameterException.
+     * @param errorResponse details for the ParameterException
+     * @param isOptional Optional parameters do not throw ParameterException in case parameter was not supplied. Mandatory parameters will throw exception if missing.
+     * @return null if parameter is not present and is optional. An integer if the string param contains an integer. An exception is thrown otherwise.
+     * @throws ParameterException
+     */
+    private Integer getIntParamFromRequest(HttpServletRequest request, String parameterName, Predicate<Integer> predicateCheckFail, JSONStreamAware errorResponse, boolean isOptional) throws ParameterException {
+        String param = request.getParameter(parameterName);
+        if(param==null){
+            if(!isOptional) {
+                throw new ParameterException(errorResponse);
+            }
+            return null;
+        }
+        Integer output;
+        try {
+            output = Integer.parseInt(param);
+            if(predicateCheckFail.test(output)) {
+                throw new ParameterException(errorResponse);
+            }
+        } catch (NumberFormatException e) {
+            throw new ParameterException(errorResponse);
+        }
+        return output;
+    }
+
+    /**
+     *
+     * @param input String cotaining either long number either RS addr (format GMD-...)
+     * @return Long id decoded
+     */
+    private long decodeAddrToLongId(String input){
+        long output = 0L;
+        if(input!=null){
+            if(input.toUpperCase().startsWith("GMD-")){
+                String rsIdStr = input.substring(4);
+                try {
+                    output = Crypto.rsDecode(rsIdStr);
+                } catch(Exception e) {}
+            } else {
+                try {
+                    output = Long.parseLong(input);
+                } catch (NumberFormatException e) {}
+            }
+        }
+        return output;
+    }
+
+    private JSONArray executePreparedStatement(PreparedStatement pstmt) throws SQLException{
+        JSONArray outputArray = new JSONArray();
+        try (ResultSet rs = pstmt.executeQuery();) {
+            while (rs.next()) {
+                JSONObject o = new JSONObject();
+                o.put("ID", rs.getLong("ID"));
+                Long recId = rs.getLong("RECIPIENT_ID");
+                if (recId != 0) {
+                    o.put("RECIPIENT_ID", "GMD-" + Crypto.rsEncode(recId));
+                }
+                o.put("TRANSACTION_INDEX", rs.getInt("TRANSACTION_INDEX"));
+                o.put("AMOUNT", rs.getLong("AMOUNT"));
+                o.put("FEE", rs.getLong("FEE"));
+                o.put("FULL_HASH", rs.getString("FULL_HASH"));
+                o.put("HEIGHT", rs.getLong("HEIGHT"));
+                o.put("BLOCK_ID", rs.getLong("BLOCK_ID"));
+                o.put("SIGNATURE", rs.getString("SIGNATURE"));
+                o.put("TIMESTAMP", rs.getLong("TIMESTAMP"));
+                o.put("SENDER_ID", "GMD-" + Crypto.rsEncode(rs.getLong("SENDER_ID")));
+                o.put("BLOCK_TIMESTAMP", rs.getLong("BLOCK_TIMESTAMP"));
+                o.put("PHASED", rs.getBoolean("PHASED"));
+                o.put("ATTACHMENT_BYTES", rs.getString("ATTACHMENT_BYTES"));
+                JSONObject type_json = new JSONObject();
+                int t = rs.getInt("TYPE");
+                int st = rs.getInt("SUBTYPE");
+                type_json.put("TYPE", t);
+                type_json.put("SUBTYPE", st);
+                try {
+                    type_json.put("type_str", type[t]);
+                } catch (Exception e) {
+                    type_json.put("type_str", "unknown");
+                }
+                try {
+                    type_json.put("subtype_str", subtype[t][st]);
+                } catch (Exception e) {
+                    type_json.put("subtype_str", "unknown");
+                }
+                o.put("type_obj", type_json);
+
+                outputArray.add(o);
+            }
+        }
+        return outputArray;
+    }
+}

--- a/src/java/nxt/http/GetLastInboundTxHeightBulk.java
+++ b/src/java/nxt/http/GetLastInboundTxHeightBulk.java
@@ -1,6 +1,8 @@
 package nxt.http;
 
+import nxt.Constants;
 import nxt.Db;
+import nxt.Nxt;
 import nxt.crypto.Crypto;
 import nxt.db.TransactionalDb;
 import org.json.simple.JSONArray;
@@ -12,16 +14,17 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.function.Predicate;
+import java.util.LinkedList;
 
 
 public class GetLastInboundTxHeightBulk extends APIServlet.APIRequestHandler {
+    static final String ACCOUNT_PREFIX = Constants.ACCOUNT_PREFIX+ "-";
     static final GetLastInboundTxHeightBulk instance = new GetLastInboundTxHeightBulk();
     protected static final TransactionalDb db = Db.db;
 
 
     private GetLastInboundTxHeightBulk() {
-        super(new APITag[] {APITag.TRANSACTIONS});
+        super(new APITag[] {APITag.TRANSACTIONS}, "listOfAccounts");
     }
 
     @Override
@@ -32,114 +35,51 @@ public class GetLastInboundTxHeightBulk extends APIServlet.APIRequestHandler {
     @Override
     protected JSONStreamAware processRequest(HttpServletRequest request) throws ParameterException {
 
-        Integer pageSize = getIntParamFromRequest(request, "pageSize", i->i<1||i>100 , JSONResponses.INCORRECT_PAGE_SIZE , false);
-        Integer page = getIntParamFromRequest(request, "page", i->i<0 , JSONResponses.INCORRECT_PAGE, false);
+        String listOfAccounts = request.getParameter("listOfAccounts"); //comma separated list of accounts
+        if(listOfAccounts == null){
+            throw new ParameterException(JSONResponses.INCORRECT_INPUT_LIST_PARAMETER);
+        }
+        String[] accounts = listOfAccounts.split(",");
+        if(accounts.length == 0){
+            throw new ParameterException(JSONResponses.INCORRECT_INPUT_LIST_PARAMETER);
+        }
 
-        long senderRSId=decodeAddrToLongId(request.getParameter("filterBySender"));
-        long recvRSId=decodeAddrToLongId(request.getParameter("filterByReceiver"));
-
-        Integer typeId, subTypeId;
-        typeId = getIntParamFromRequest(request, "filterByType", i->false, JSONResponses.INCORRECT_TYPE, true);
-        subTypeId = getIntParamFromRequest(request, "filterBySubtype", i->false, JSONResponses.INCORRECT_SUBTYPE , true);
-
-        Integer minHeight, maxHeight;
-        minHeight = getIntParamFromRequest(request, "minHeight", i->i<0, JSONResponses.INCORRECT_MIN_HEIGHT, true);
-        maxHeight = getIntParamFromRequest(request, "maxHeight", i->(i<0 || (minHeight!=null&& minHeight > i)), JSONResponses.INCORRECT_MAX_HEIGHT, true);
-
-
-
-        try (Connection con = db.getConnection(); PreparedStatement pstmt = con.prepareStatement(
-                "SELECT * "+
-                        "FROM TRANSACTION " +
-                        "WHERE TRUE "+
-                        (senderRSId!=0 ? "AND ? = SENDER_ID ":"") +
-                        (recvRSId!=0 ? "AND ? = RECIPIENT_ID ":"") +
-                        (typeId!=null ? "AND ? = TYPE ":"") +
-                        (subTypeId!=null ? "AND ? = SUBTYPE ":"") +
-                        (minHeight!=null? "AND ? <= HEIGHT ": "") +
-                        (maxHeight!=null? "AND ? >= HEIGHT ": "") +
-                        "ORDER BY TIMESTAMP DESC " +
-                        "OFFSET ? ROWS FETCH NEXT ? ROWS ONLY")) {
-            int offset = 0;
-            if (senderRSId!=0){
-                pstmt.setLong(++offset,senderRSId);
+        LinkedList<String> accountIds = new LinkedList<>();
+        for(String account : accounts){
+            String accountId = rsToLongId(account);
+            if(accountId!=null){
+                accountIds.add(accountId);
             }
-            if (recvRSId!=0){
-                pstmt.setLong(++offset,recvRSId);
-            }
-            if(typeId!=null){
-                pstmt.setInt(++offset,typeId);
-            }
-            if(subTypeId!=null){
-                pstmt.setInt(++offset,subTypeId);
-            }
-            if(minHeight!=null){
-                pstmt.setInt(++offset,minHeight);
-            }
-            if(maxHeight!=null){
-                pstmt.setInt(++offset,maxHeight);
-            }
-            pstmt.setInt(++offset, page*pageSize);
-            pstmt.setInt(++offset, pageSize);
+        }
+        if (accountIds.size() == 0){
+            throw new ParameterException(JSONResponses.INCORRECT_INPUT_LIST_PARAMETER);
+        }
 
+        String queryList = String.join(",", accountIds);
+
+
+        String query = "SELECT MAX(TRANSACTION.HEIGHT) AS HEIGHT_LAST_TRANSACTION, ACCOUNT.ID, ACCOUNT.UNCONFIRMED_BALANCE "+
+                "FROM TRANSACTION LEFT JOIN ACCOUNT ON TRANSACTION.RECIPIENT_ID=ACCOUNT.ID "+
+                "WHERE ACCOUNT.ID IN ("+ queryList +") "+
+                "AND ACCOUNT.LATEST=TRUE GROUP BY TRANSACTION.RECIPIENT_ID ORDER BY HEIGHT_LAST_TRANSACTION DESC";
+        try (Connection con = db.getConnection(); PreparedStatement pstmt = con.prepareStatement(query)) {
             JSONObject response = new JSONObject();
-            response.put("Transactions", executePreparedStatement(pstmt));
+            response.put("results", executePreparedStatement(pstmt));
+            response.put("currentHeight", Nxt.getBlockchain().getHeight());
             return response;
         } catch (SQLException e) {
             throw new RuntimeException(e.toString(), e);
         }
     }
 
-    /**
-     *
-     * @param request
-     * @param parameterName
-     * @param predicateCheckFail condition to be applied on the output integer. If true will throw ParameterException.
-     * @param errorResponse details for the ParameterException
-     * @param isOptional Optional parameters do not throw ParameterException in case parameter was not supplied. Mandatory parameters will throw exception if missing.
-     * @return null if parameter is not present and is optional. An integer if the string param contains an integer. An exception is thrown otherwise.
-     * @throws ParameterException
-     */
-    private Integer getIntParamFromRequest(HttpServletRequest request, String parameterName, Predicate<Integer> predicateCheckFail, JSONStreamAware errorResponse, boolean isOptional) throws ParameterException {
-        String param = request.getParameter(parameterName);
-        if(param==null){
-            if(!isOptional) {
-                throw new ParameterException(errorResponse);
-            }
+
+
+    private String rsToLongId(String input){
+        try {
+            return ""+Crypto.rsDecode(input.toUpperCase().startsWith(ACCOUNT_PREFIX) ? input.substring(4) : input);
+        } catch(Exception e) {
             return null;
         }
-        Integer output;
-        try {
-            output = Integer.parseInt(param);
-            if(predicateCheckFail.test(output)) {
-                throw new ParameterException(errorResponse);
-            }
-        } catch (NumberFormatException e) {
-            throw new ParameterException(errorResponse);
-        }
-        return output;
-    }
-
-    /**
-     *
-     * @param input String cotaining either long number either RS addr (format GMD-...)
-     * @return Long id decoded
-     */
-    private long decodeAddrToLongId(String input){
-        long output = 0L;
-        if(input!=null){
-            if(input.toUpperCase().startsWith("GMD-")){
-                String rsIdStr = input.substring(4);
-                try {
-                    output = Crypto.rsDecode(rsIdStr);
-                } catch(Exception e) {}
-            } else {
-                try {
-                    output = Long.parseLong(input);
-                } catch (NumberFormatException e) {}
-            }
-        }
-        return output;
     }
 
     private JSONArray executePreparedStatement(PreparedStatement pstmt) throws SQLException{
@@ -147,39 +87,9 @@ public class GetLastInboundTxHeightBulk extends APIServlet.APIRequestHandler {
         try (ResultSet rs = pstmt.executeQuery();) {
             while (rs.next()) {
                 JSONObject o = new JSONObject();
-                o.put("ID", rs.getLong("ID"));
-                Long recId = rs.getLong("RECIPIENT_ID");
-                if (recId != 0) {
-                    o.put("RECIPIENT_ID", "GMD-" + Crypto.rsEncode(recId));
-                }
-                o.put("TRANSACTION_INDEX", rs.getInt("TRANSACTION_INDEX"));
-                o.put("AMOUNT", rs.getLong("AMOUNT"));
-                o.put("FEE", rs.getLong("FEE"));
-                o.put("FULL_HASH", rs.getString("FULL_HASH"));
-                o.put("HEIGHT", rs.getLong("HEIGHT"));
-                o.put("BLOCK_ID", rs.getLong("BLOCK_ID"));
-                o.put("SIGNATURE", rs.getString("SIGNATURE"));
-                o.put("TIMESTAMP", rs.getLong("TIMESTAMP"));
-                o.put("SENDER_ID", "GMD-" + Crypto.rsEncode(rs.getLong("SENDER_ID")));
-                o.put("BLOCK_TIMESTAMP", rs.getLong("BLOCK_TIMESTAMP"));
-                o.put("PHASED", rs.getBoolean("PHASED"));
-                o.put("ATTACHMENT_BYTES", rs.getString("ATTACHMENT_BYTES"));
-                JSONObject type_json = new JSONObject();
-                int t = rs.getInt("TYPE");
-                int st = rs.getInt("SUBTYPE");
-                type_json.put("TYPE", t);
-                type_json.put("SUBTYPE", st);
-                try {
-                    type_json.put("type_str", type[t]);
-                } catch (Exception e) {
-                    type_json.put("type_str", "unknown");
-                }
-                try {
-                    type_json.put("subtype_str", subtype[t][st]);
-                } catch (Exception e) {
-                    type_json.put("subtype_str", "unknown");
-                }
-                o.put("type_obj", type_json);
+                o.put("account", ACCOUNT_PREFIX +Crypto.rsEncode(rs.getLong("ID")));
+                o.put("height", rs.getInt("HEIGHT_LAST_TRANSACTION"));
+                o.put("balance", ""+rs.getLong("UNCONFIRMED_BALANCE"));
 
                 outputArray.add(o);
             }

--- a/src/java/nxt/http/JSONResponses.java
+++ b/src/java/nxt/http/JSONResponses.java
@@ -163,6 +163,7 @@ public final class JSONResponses {
     public static final JSONStreamAware INCORRECT_MIN_HEIGHT = incorrect("minHeight", "Minimum blockchain height must be positive integer.");
     public static final JSONStreamAware INCORRECT_MAX_HEIGHT = incorrect("maxHeight", "Maximum blockchain height must be positive integer greater than minHeight.");
     public static final JSONStreamAware INCORRECT_MIN_BALANCE = incorrect("minUnconfirmedBalanceNQT", "Could not parse");
+    public static final JSONStreamAware INCORRECT_INPUT_LIST_PARAMETER = incorrect("listOfAccounts", "Should be comma separated list of accounts");
 
     public static final JSONStreamAware NOT_ENOUGH_FUNDS;
     static {

--- a/src/java/nxt/http/callers/ApiSpec.java
+++ b/src/java/nxt/http/callers/ApiSpec.java
@@ -109,6 +109,8 @@ public enum ApiSpec {
 
     getAccountsBulk(null, "minBalanceNQT", "pageSize", "page", "includeDescription", "includeEffectiveBalance"),
 
+    getLastInboundTxHeightBulk(null, "listOfAccounts"),
+
     getMaxSupply(null, ""),
 
     getTotalSupply(null, ""),


### PR DESCRIPTION
Add new getter to the API that retrieves a list of wallet balances and the height of their last inbound transaction.
This feature was requested by the community to facilitate observing multiple wallets with single call. This was tested with a list of 8000 wallets and the call takes some time on the order of milliseconds. 